### PR TITLE
Avoid header file name clashes due to libjson / jsoncpp

### DIFF
--- a/libpubnub-cpp/Makefile
+++ b/libpubnub-cpp/Makefile
@@ -1,7 +1,7 @@
 # Compile using `make XCFLAGS=-DDEBUG` to enable debugging code.
 CUSTOM_CXXFLAGS=-Wall -ggdb3 -O3
 SOFLAGS=-fPIC -fvisibility=internal
-SYS_CXXFLAGS=$(SOFLAGS) -I. -I../libpubnub `pkg-config --cflags json libcurl libcrypto libevent`
+SYS_CXXFLAGS=$(SOFLAGS) -I. -I../libpubnub `pkg-config --cflags libcurl libcrypto libevent`
 LIBS=`pkg-config --libs json libcurl libcrypto libevent`
 LDFLAGS=$(SOFLAGS) -shared -Wl,-soname,libpubnub-cpp.so.1
 

--- a/libpubnub-cpp/pubnub-sync.cpp
+++ b/libpubnub-cpp/pubnub-sync.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <vector>
 
-#include <json.h>
+#include <json/json.h>
 
 #include "pubnub.hpp"
 #include "pubnub-sync.hpp"

--- a/libpubnub-cpp/pubnub.cpp
+++ b/libpubnub-cpp/pubnub.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-#include <json.h>
+#include <json/json.h>
 
 #include "pubnub.hpp"
 #include "pubnub.h"

--- a/libpubnub-cpp/pubnub.hpp
+++ b/libpubnub-cpp/pubnub.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <json.h>
+#include <json/json.h>
 
 #include <pubnub.h>
 

--- a/libpubnub/Makefile
+++ b/libpubnub/Makefile
@@ -1,7 +1,7 @@
 # Compile using `make XCFLAGS=-DDEBUG` to enable debugging code.
 CUSTOM_CFLAGS=-Wall -ggdb3 -O3
 SOFLAGS=-fPIC -fvisibility=internal
-SYS_CFLAGS=-std=gnu99 $(SOFLAGS) -I. `pkg-config --cflags json libcurl libcrypto libevent`
+SYS_CFLAGS=-std=gnu99 $(SOFLAGS) -I. `pkg-config --cflags libcurl libcrypto libevent`
 LIBS=`pkg-config --libs json libcurl libcrypto libevent`
 LDFLAGS=$(SOFLAGS) -shared -Wl,-soname,libpubnub.so.1
 

--- a/libpubnub/crypto.c
+++ b/libpubnub/crypto.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <json.h>
+#include <json/json.h>
 
 #include <openssl/evp.h>
 #include <openssl/bio.h>

--- a/libpubnub/pubnub-priv.h
+++ b/libpubnub/pubnub-priv.h
@@ -1,7 +1,7 @@
 #ifndef PUBNUB__PubNub_priv_h
 #define PUBNUB__PubNub_priv_h
 
-#include <printbuf.h>
+#include <json/printbuf.h>
 #include <curl/curl.h>
 
 #include "pubnub.h"

--- a/libpubnub/pubnub.c
+++ b/libpubnub/pubnub.c
@@ -4,8 +4,8 @@
 #include <string.h>
 #include <time.h>
 
-#include <json.h>
-#include <printbuf.h>
+#include <json/json.h>
+#include <json/printbuf.h>
 
 #include <curl/curl.h>
 #include <openssl/ssl.h>

--- a/libpubnub/pubnub.h
+++ b/libpubnub/pubnub.h
@@ -11,7 +11,7 @@ typedef int bool;
 
 #include <time.h>
 
-#include <json.h>
+#include <json/json.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
On my Linux Mint machine at work, I ran into problems while makeing the sdk: the line `-I pkg-config --cflags json [...]` in the Makefiles expands to `-I/usr/include/json [...]`. Now `pubnub.c` includes `assert.h`, which has, on my machine at least, a line `#include <features.h>`. And guess what: `jsoncpp` (also on my machine, not needed for the sdk) has a file in `include/json` named `features.h`, which gets included by `assert.h` because of the `-I` path. Things get ugly then.

Thanks.
